### PR TITLE
解决服务端运行错误（Log4j2 找不到日志实现）

### DIFF
--- a/music-server/pom.xml
+++ b/music-server/pom.xml
@@ -86,6 +86,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.8.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>


### PR DESCRIPTION
服务端运行报错（ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...）
添加如下依赖后正常启动成功了。
不知道是不是我个人的问题，试着提交一下。